### PR TITLE
add helper modules for setup

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
         run: sed -i 's/@version \".*\"/@version "${{ env.RELEASE_VERSION }}"/g' mix.exs
       - name: Save version
         if: github.event_name == 'release'
-        uses: github-actions-x/commit@5cf7985b07155682f82d02b6c2188d90cebeb0c8
+        uses: github-actions-x/commit@722d56b8968bf00ced78407bbe2ead81062d8baa
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           push-branch: main

--- a/lib/reactive_commons/runtime/reactive_commons_setup.ex
+++ b/lib/reactive_commons/runtime/reactive_commons_setup.ex
@@ -1,0 +1,43 @@
+defmodule ReactiveCommonsSetup do
+  @doc """
+  Get config of type AsyncConfig.
+  """
+  @callback config() :: map()
+
+  defmacro __using__(opts) do
+    quote do
+      use Supervisor
+
+      def start_link(args) do
+        Supervisor.start_link(__MODULE__, args, name: __MODULE__)
+      end
+
+      @impl true
+      def init(_args) do
+        conn_config = config() |> merge()
+        subs_config = handlers_config()
+        children = [
+          {MessageRuntime, conn_config},
+          {SubsConfigProcess, subs_config}
+        ]
+
+        Supervisor.init(children, strategy: :one_for_one)
+      end
+
+
+      defp merge(params) when is_map(params) do
+        Application.get_application(__MODULE__)
+        |> Atom.to_string()
+        |> AsyncConfig.new()
+        |> Map.merge(params)
+      end
+
+      @doc """
+      Get config of type HandlersConfig.
+      """
+      defp handlers_config(), do: %HandlersConfig{}
+
+      defoverridable handlers_config: 0
+    end
+  end
+end

--- a/lib/reactive_commons/runtime/subs_config_process.ex
+++ b/lib/reactive_commons/runtime/subs_config_process.ex
@@ -1,0 +1,13 @@
+defmodule SubsConfigProcess do
+  use GenServer
+
+  def start_link(config = %HandlersConfig{}) do
+    GenServer.start_link(__MODULE__, config, name: __MODULE__)
+  end
+
+  @impl true
+  def init(config) do
+    :ok = HandlerRegistry.commit_config(config)
+    :ignore
+  end
+end


### PR DESCRIPTION
Add helper module to easy config setup like:

```elixir
defmodule SampleCa.Adapters.MessageRuntimeConfig do
  alias SampleCa.Config.{ConfigHolder, AppConfig}
  use ReactiveCommonsSetup
  @event_name "PersonRegistered"

  defp config() do
    Application.get_env(:sample_ca, :exchange)
  end

  defp handlers_config() do
    HandlerRegistry.listen_event(@event_name, &person_registered/1)
  end

  def person_registered(%{} = event) do
    IO.puts "Handling event #{inspect(event)}"
  end

end

```